### PR TITLE
handle exceptions thrown to zone handlers in @failingTests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@
 .settings/
 build/
 packages
+.packages
 pubspec.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
 # Changelog
 
+## 0.1.1
+
+- For `@failingTest` tests, properly handle when the test fails by throwing an
+  exception in a timer task
+- Analyze this package in strong mode
+
 ## 0.1.0
 
 - Switched from 'package:unittest' to 'package:test'.
-- Since 'package:test' does not define 'solo_test', in order to keep
-  this functionality, `defineReflectiveSuite` must be used to wrap
-  all `defineReflectiveTests` invocations.
+- Since 'package:test' does not define 'solo_test', in order to keep this
+  functionality, `defineReflectiveSuite` must be used to wrap all
+  `defineReflectiveTests` invocations.
 
 ## 0.0.4
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,5 @@
+analyzer:
+  strong-mode: true
+linter:
+  rules:
+    - directives_ordering

--- a/lib/test_reflective_loader.dart
+++ b/lib/test_reflective_loader.dart
@@ -223,14 +223,18 @@ Future _invokeSymbolIfExists(InstanceMirror instanceMirror, Symbol symbol) {
  * This properly handles the following cases:
  * - The test fails by throwing an exception
  * - The test returns a future which completes with an error.
- *
- * However, it does not handle the case where the test creates an asynchronous
- * callback using expectAsync(), and that callback generates a failure.
+ * - An exception is thrown to the zone handler from a timer task.
  */
 Future _runFailingTest(ClassMirror classMirror, Symbol symbol) {
-  return new Future(() => _runTest(classMirror, symbol)).then((_) {
-    test_package.fail('Test passed - expected to fail.');
-  }, onError: (_) {});
+  return runZoned(() {
+    return new Future.sync(() => _runTest(classMirror, symbol)).then((_) {
+      test_package.fail('Test passed - expected to fail.');
+    }).catchError((e) {
+      // an exception is not a failure for _runFailingTest
+    });
+  }, onError: (e) {
+    // an exception is not a failure for _runFailingTest
+  });
 }
 
 _runTest(ClassMirror classMirror, Symbol symbol) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_reflective_loader
-version: 0.1.0
+version: 0.1.1
 description: Support for discovering tests and test suites using reflection.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/test_reflective_loader


### PR DESCRIPTION
@scheglov, this updates the way that `@failingTest` annotations are handled to catch exceptions from timer tasks (that would fail the test, but would not be passed back from any Future returned by the test). I see these types of failures in some analysis server integration tests (the exception is caught in a timer task, that calls package:test `fail()`, and fails the test).