### PR TITLE
Require at least SDK 1.8.0 because 'pub publish' demands this.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/test_reflective_loader
 
 environment:
-  sdk: '>=1.0.0 <2.0.0'
+  sdk: '>=1.8.0 <2.0.0'
 
 dependencies:
   test: ^0.12.0


### PR DESCRIPTION
```
Missing requirements:
* Older versions of pub don't support ^ version constraints.
  Make sure your SDK constraint excludes old versions:

  environment:
    sdk: ">=1.8.0 <2.0.0"
Sorry, your package is missing a requirement and can't be published yet.
For more information, see: http://pub.dartlang.org/doc/pub-lish.html.
```