### PR TITLE
Update comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.7
+
+- Update documentation comments.
+- Remove `@MirrorsUsed` annotation on `dart:mirrors`.
+
 ## 0.1.6
 
 - Make `FailingTest` public, with the URI of the issue that causes

--- a/lib/test_reflective_loader.dart
+++ b/lib/test_reflective_loader.dart
@@ -287,9 +287,8 @@ class TestTimeout {
 }
 
 /**
- * A marker annotation used to annotate overridden test methods (so we cannot
- * rename them to `fail_`) which are expected to fail at `assert` in the
- * checked mode.
+ * A marker annotation used to annotate test methods which are expected to fail
+ * when asserts are enabled.
  */
 class _AssertFailingTest {
   const _AssertFailingTest();

--- a/lib/test_reflective_loader.dart
+++ b/lib/test_reflective_loader.dart
@@ -5,21 +5,18 @@
 library test_reflective_loader;
 
 import 'dart:async';
-@MirrorsUsed(metaTargets: 'ReflectiveTest')
 import 'dart:mirrors';
 
 import 'package:test/test.dart' as test_package;
 
 /**
- * A marker annotation used to annotate overridden test methods (so we cannot
- * rename them to `fail_`) which are expected to fail at `assert` in the
- * checked mode.
+ * A marker annotation used to annotate test methods which are expected to fail
+ * when asserts are enabled.
  */
 const _AssertFailingTest assertFailingTest = const _AssertFailingTest();
 
 /**
- * A marker annotation used to annotate overridden test methods (so we cannot
- * rename them to `fail_`) which are expected to fail.
+ * A marker annotation used to annotate test methods which are expected to fail.
  */
 const FailingTest failingTest = const FailingTest(null);
 
@@ -267,10 +264,12 @@ Future _runTest(ClassMirror classMirror, Symbol symbol) {
 typedef dynamic _TestFunction();
 
 /**
- * A marker annotation used to annotate overridden test methods (so we cannot
- * rename them to `fail_`) which are expected to fail.
+ * A marker annotation used to annotate test methods which are expected to fail.
  */
 class FailingTest {
+  /**
+   * Initialize this annotation with the given issue URI.
+   */
   const FailingTest(String issueUri);
 }
 
@@ -279,9 +278,12 @@ class FailingTest {
  * information.
  */
 class TestTimeout {
-  final test_package.Timeout timeout;
+  final test_package.Timeout _timeout;
 
-  const TestTimeout(this.timeout);
+  /**
+   * Initialize this annotation with the given timeout.
+   */
+  const TestTimeout(test_package.Timeout timeout) : _timeout = timeout;
 }
 
 /**
@@ -309,7 +311,7 @@ class _Group {
       _TestFunction function) {
     String fullName = _combineNames(this.name, name);
     TestTimeout timeout = _getAnnotationInstance(memberMirror, TestTimeout);
-    tests.add(new _Test(isSolo, fullName, function, timeout?.timeout));
+    tests.add(new _Test(isSolo, fullName, function, timeout?._timeout));
   }
 }
 


### PR DESCRIPTION
I removed mentions of `fail_` from comments - at some point we decided to stop using them at all.
But we still support it for now, we might remove it finally when we change our codebase.