### PR TITLE
Revert "stable null safety release"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 0.2.0
-
-- Stable null safety release.
-
 ## 0.2.0-nullsafety.0
 
 - Migrate to the null safety language feature.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,8 @@
 name: test_reflective_loader
-version: 0.2.0
+version: 0.2.0-nullsafety.0
 
 description: Support for discovering tests and test suites using reflection.
+author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/test_reflective_loader
 
 environment:


### PR DESCRIPTION
Reverts dart-lang/test_reflective_loader#31

I should have updated `package:test` dependency.