### PR TITLE
0.2.2

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,6 +9,9 @@ on:
     # “At 00:00 (UTC) on Sunday.”
     - cron: '0 0 * * 0'
 
+env:
+  PUB_ENVIRONMENT: bot.github
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
           sdk: dev
 
       - name: pub get
-        run: pub get
+        run: dart pub get
 
       - name: dart format
         run: dart format --output=none --set-exit-if-changed .

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,13 +15,17 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sdk: [dev, stable]
 
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1
         with:
-          sdk: dev
-
+          sdk: ${{ matrix.sdk }}
+          
       - name: pub get
         run: dart pub get
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,6 +15,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: dev
 
       - name: pub get
         run: pub get

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,9 +13,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    container:
-      image:  google/dart:beta
-
     steps:
       - uses: actions/checkout@v2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.2
+
+- Update to package:lints 2.0.0 and move it to a dev dependency.
+
 ## 0.2.1
 
 - Use package:lints for analysis.

--- a/lib/test_reflective_loader.dart
+++ b/lib/test_reflective_loader.dart
@@ -13,28 +13,28 @@ import 'package:test/test.dart' as test_package;
  * A marker annotation used to annotate test methods which are expected to fail
  * when asserts are enabled.
  */
-const _AssertFailingTest assertFailingTest = _AssertFailingTest();
+const Object assertFailingTest = _AssertFailingTest();
 
 /**
  * A marker annotation used to annotate test methods which are expected to fail.
  */
-const FailingTest failingTest = FailingTest();
+const Object failingTest = FailingTest();
 
 /**
  * A marker annotation used to instruct dart2js to keep reflection information
  * for the annotated classes.
  */
-const _ReflectiveTest reflectiveTest = _ReflectiveTest();
+const Object reflectiveTest = _ReflectiveTest();
 
 /**
  * A marker annotation used to annotate test methods that should be skipped.
  */
-const SkippedTest skippedTest = SkippedTest();
+const Object skippedTest = SkippedTest();
 
 /**
  * A marker annotation used to annotate "solo" groups and tests.
  */
-const _SoloTest soloTest = _SoloTest();
+const Object soloTest = _SoloTest();
 
 final List<_Group> _currentGroups = <_Group>[];
 int _currentSuiteLevel = 0;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,5 +7,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  lints: ^1.0.0
   test: ^1.16.0
+
+dev_dependencies:
+  lints: ^2.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_reflective_loader
-version: 0.2.1
+version: 0.2.2
 description: Support for discovering tests and test suites using reflection.
 repository: https://github.com/dart-lang/test_reflective_loader
 


### PR DESCRIPTION
This change:

* updates to the latest `package:lints`
* moves the `package:lints` dependency to a `dev_dependency`
* addresses newly flagged private members in the public API